### PR TITLE
Add support for checking GitHub event type in main function

### DIFF
--- a/github/__init__.py
+++ b/github/__init__.py
@@ -5,6 +5,7 @@ import azure.functions as func
 
 from hemera.exceptions import (
     EnvironmentVariableNotSetError,
+    GithubEventNotSupportedError,
     HemeraError,
     UnauthorizedUserError,
 )
@@ -46,6 +47,9 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
         hemera_http_request = HemeraHttpRequest.from_azure_functions_http_request(
             req=req, logger=LOGGER
         )
+
+        if hemera_http_request.githubevent != "pull_request":
+            raise GithubEventNotSupportedError
 
         if hemera_http_request.username != allowed_username:
             raise UnauthorizedUserError

--- a/src/hemera/exceptions.py
+++ b/src/hemera/exceptions.py
@@ -57,3 +57,10 @@ class AutomationHandlerException(HemeraError):
 
     def __init__(self):
         raise HemeraError("Error in AutomationHandler class.")
+
+
+class GithubEventNotSupportedError(HemeraError):
+    """Raised when a GitHub event is not supported."""
+
+    def __init__(self):
+        raise HemeraError("GitHub event not supported.")

--- a/src/hemera/slack.py
+++ b/src/hemera/slack.py
@@ -23,9 +23,12 @@ def create_slack_message(hemera_http_request: HemeraHttpRequest) -> str:
     """
     try:
         return (
-            f"The following action [{hemera_http_request.action}] "
-            f"was performed on the repository: {hemera_http_request.repository}\n"
-            f"The action was performed by: {hemera_http_request.username}\n"
+            f"{hemera_http_request.username} {hemera_http_request.action} a {hemera_http_request.githubevent}\n"
+            f"<{hemera_http_request.pullrequesturl}|"
+            f"{hemera_http_request.pullrequestnumber}: {hemera_http_request.pullrequesttitle}>\n"
+            f"Target branch: {hemera_http_request.pullrequesttargetbranch}; "
+            f"Source branch: {hemera_http_request.pullrequestsourcebranch}\n"
+            f"Repository: {hemera_http_request.repository}\n"
             f"Created by Hemera v{hemera_http_request.metadata.core}"
         )
     except Exception as e:

--- a/src/hemera/types.py
+++ b/src/hemera/types.py
@@ -100,7 +100,16 @@ class HemeraHttpRequest:
             str: The username of the user who performed the action on the repository.
         """
         try:
-            return self.req.body["sender"]["login"]  # type: ignore
+            body: dict = self.req.body
+            return body["pull_request"]["user"]["login"]
+            # Fields that contains a username:
+            # body["pull_request"]["user"]["login"]
+            # body["pull_request"]["head"]["user"]["login"]
+            # body["pull_request"]["head"]["repo"]["owner"]["login"]
+            # body["pull_request"]["base"]["user"]["login"]
+            # body["pull_request"]["base"]["repo"]["owner"]["login"]
+            # body["repository"]["owner"]["login"]
+            # body["sender"]["login"]
         except KeyError as e:
             raise ValueNotFoundInHemeraHttpRequest from e
 
@@ -115,7 +124,8 @@ class HemeraHttpRequest:
             object: The action performed on the repository.
         """
         try:
-            return self.req.body["action"]
+            body: dict = self.req.body
+            return body["action"]
         except KeyError as e:
             raise ValueNotFoundInHemeraHttpRequest from e
 
@@ -130,6 +140,110 @@ class HemeraHttpRequest:
             str: The full name of the repository.
         """
         try:
-            return self.req.body["repository"]["full_name"]  # type: ignore
+            body: dict = self.req.body
+            return body["repository"]["full_name"]
+            # Fields that contains a repository name:
+            # body["pull_request"]["head"]["repo"]["full_name"]
+            # body["pull_request"]["base"]["repo"]["full_name"]
+            # body["repository"]["full_name"]
+        except KeyError as e:
+            raise ValueNotFoundInHemeraHttpRequest from e
+
+    @property
+    def githubevent(self) -> str:
+        """Return the GitHub event type.
+
+        Raises:
+            ValueNotFoundInHemeraHttpRequest: When the GitHub event type is not found.
+
+        Returns:
+            str: The GitHub event type.
+        """
+        try:
+            header: dict = self.req.header
+            return header["x-github-event"]
+        except KeyError as e:
+            raise ValueNotFoundInHemeraHttpRequest from e
+
+    @property
+    def pullrequesturl(self) -> str:
+        """Return the pull request URL.
+
+        Raises:
+            ValueNotFoundInHemeraHttpRequest: When the pull request URL is not found.
+
+        Returns:
+            str: The pull request URL.
+        """
+        try:
+            body: dict = self.req.body
+            return body["pull_request"]["html_url"]
+        except KeyError as e:
+            raise ValueNotFoundInHemeraHttpRequest from e
+
+    @property
+    def pullrequestnumber(self) -> str:
+        """Return the pull request number.
+
+        Raises:
+            ValueNotFoundInHemeraHttpRequest: When the pull request number is not found.
+
+        Returns:
+            str: The pull request number.
+        """
+        try:
+            body: dict = self.req.body
+            return body["pull_request"]["number"]
+            # Fields that contains a pull request number:
+            # body["pull_request"]["number"]
+            # body["number"]
+        except KeyError as e:
+            raise ValueNotFoundInHemeraHttpRequest from e
+
+    @property
+    def pullrequesttitle(self) -> str:
+        """Return the pull request title.
+
+        Raises:
+            ValueNotFoundInHemeraHttpRequest: When the pull request title is not found.
+
+        Returns:
+            str: The pull request title.
+        """
+        try:
+            body: dict = self.req.body
+            return body["pull_request"]["title"]
+        except KeyError as e:
+            raise ValueNotFoundInHemeraHttpRequest from e
+
+    @property
+    def pullrequesttargetbranch(self) -> str:
+        """Return the pull request target branch.
+
+        Raises:
+            ValueNotFoundInHemeraHttpRequest: When the pull request target branch is not found.
+
+        Returns:
+            str: The pull request target branch.
+        """
+        try:
+            body: dict = self.req.body
+            return body["pull_request"]["base"]["ref"]
+        except KeyError as e:
+            raise ValueNotFoundInHemeraHttpRequest from e
+
+    @property
+    def pullrequestsourcebranch(self) -> str:
+        """Return the pull request source branch.
+
+        Raises:
+            ValueNotFoundInHemeraHttpRequest: When the pull request source branch is not found.
+
+        Returns:
+            str: The pull request source branch.
+        """
+        try:
+            body: dict = self.req.body
+            return body["pull_request"]["head"]["ref"]
         except KeyError as e:
             raise ValueNotFoundInHemeraHttpRequest from e

--- a/tests/hemera/conftest.py
+++ b/tests/hemera/conftest.py
@@ -45,3 +45,10 @@ def set_env_vars():
     os_environ.pop("SLACK_CHANNEL", None)
     os_environ.pop("HOMEAUTOMATION_WEBHOOK", None)
     os_environ.pop("ALLOWED_USERNAME", None)
+
+
+@pytest.fixture
+def incorrect_github_event_header():
+    header = HEADER.copy()
+    header["x-github-event"] = "incorrect_event"
+    return header

--- a/tests/hemera/test_api_github.py
+++ b/tests/hemera/test_api_github.py
@@ -50,8 +50,10 @@ def test_github_api_message_sent_to_slack_successfully(
             json={
                 "channel": "fake_channel",
                 "text": (
-                    "The following action [reopened] was performed on the repository: "
-                    "username/repository_name\nThe action was performed by: username\n"
+                    "username reopened a pull_request\n"
+                    "<http://fakeurl.com|17: PR title>\n"
+                    "Target branch: master; Source branch: branch_name\n"
+                    "Repository: username/repository_name\n"
                     "Created by Hemera v0.0.0"
                 ),
             },

--- a/tests/hemera/test_api_github.py
+++ b/tests/hemera/test_api_github.py
@@ -70,3 +70,19 @@ def test_github_api_username_not_allowed(test_request: func.HttpRequest):
     test = github_api(req=test_request)
     assert test.get_body().decode() == "Error: Unauthorized user."
     assert test.status_code == 400
+
+
+def test_github_event_not_supported_error(incorrect_github_event_header: dict):
+    """Test github_api when the event is not supported."""
+    test = github_api(
+        req=func.HttpRequest(
+            method="POST",
+            url="/",
+            headers=incorrect_github_event_header,
+            params={},
+            route_params={},
+            body=json.dumps({}).encode("utf-8"),
+        )
+    )
+    assert test.get_body().decode() == "Error: GitHub event not supported."
+    assert test.status_code == 400

--- a/tests/hemera/test_slack.py
+++ b/tests/hemera/test_slack.py
@@ -36,12 +36,16 @@ def test_send_slack_message_error(api_call=MagicMock()):
 
 def test_create_slack_message(hemera_http_request):
     """Test create_slack_message."""
-    assert create_slack_message(
-        hemera_http_request=hemera_http_request,
-    ) == (
-        "The following action [reopened] was performed on the repository: username/repository_name\n"
-        "The action was performed by: username\n"
+    expected_message = (
+        "username reopened a pull_request\n"
+        "<http://fakeurl.com|17: PR title>\n"
+        "Target branch: master; Source branch: branch_name\n"
+        "Repository: username/repository_name\n"
         "Created by Hemera v0.0.0"
+    )
+    assert (
+        create_slack_message(hemera_http_request=hemera_http_request)
+        == expected_message
     )
 
 

--- a/tests/hemera/test_types.py
+++ b/tests/hemera/test_types.py
@@ -17,6 +17,21 @@ def test_hemera_http_request_exceptions():
     with pytest.raises(HemeraError, match="Value not found in HemeraHttpRequest."):
         _ = http_request.repository
 
+    with pytest.raises(HemeraError, match="Value not found in HemeraHttpRequest."):
+        _ = http_request.pullrequesturl
+
+    with pytest.raises(HemeraError, match="Value not found in HemeraHttpRequest."):
+        _ = http_request.pullrequestnumber
+
+    with pytest.raises(HemeraError, match="Value not found in HemeraHttpRequest."):
+        _ = http_request.pullrequesttitle
+
+    with pytest.raises(HemeraError, match="Value not found in HemeraHttpRequest."):
+        _ = http_request.pullrequesttargetbranch
+
+    with pytest.raises(HemeraError, match="Value not found in HemeraHttpRequest."):
+        _ = http_request.pullrequestsourcebranch
+
 
 def test_hemera_meta_data_exceptions():
     """Test HemeraMetadata exceptions."""


### PR DESCRIPTION
Add properties to HemeraHttpRequest class to retrieve GitHub event type, pull request URL, pull request number, pull request title, pull request target branch, and pull request source branch

Update create_slack_message function to include the GitHub event type and pull request details in the Slack message