### PR TITLE
Add deprecated environment variable scanning

### DIFF
--- a/src/hemera/dataclasses.py
+++ b/src/hemera/dataclasses.py
@@ -22,3 +22,12 @@ class Metadata:
     """Dataclass for Hemera metadata."""
 
     python: PythonVersion
+
+
+@dataclass
+class DeprecatedEnvirionmentVariable:
+    """Dataclass for deprecated environment variables."""
+
+    name: str
+    deprecated_in_hemera_version: str
+    replacement: str

--- a/src/hemera/deprecated.py
+++ b/src/hemera/deprecated.py
@@ -1,0 +1,36 @@
+from logging import Logger, getLogger
+from os import environ as os_environ
+
+from hemera.dataclasses import DeprecatedEnvirionmentVariable
+from hemera.exceptions import EnvironmentVariableDeprecatedError
+from hemera.metadata import get_software_versions
+
+DEPRECATEDENVIRIONMENTVARIABLES = [
+    DeprecatedEnvirionmentVariable(
+        name="ALLOWED_USERNAME",
+        deprecated_in_hemera_version="2.0.0",
+        replacement="PR_AUTHOR_FILTER",
+    )
+]
+
+LOGGER = getLogger(__name__)
+
+
+def scan_for_deprecated_env_vars(
+    deprecated_env_vars: list, logger: Logger = LOGGER
+) -> None:
+    """Scan for deprecated environment variables."""
+
+    hemera_version = get_software_versions(distribution="hemera").package["hemera"]
+
+    for envirionment_variable in deprecated_env_vars:
+        if envirionment_variable.name in os_environ:
+            logger.warning(
+                f"The environment variable {envirionment_variable.name} "
+                f"is deprecated in Hemera {envirionment_variable.deprecated_in_hemera_version} "
+                f"You should use {envirionment_variable.replacement} instead."
+            )
+            if hemera_version >= envirionment_variable.deprecated_in_hemera_version:
+                raise EnvironmentVariableDeprecatedError(
+                    env_var_name=envirionment_variable.name
+                )

--- a/src/hemera/deprecated.py
+++ b/src/hemera/deprecated.py
@@ -19,7 +19,15 @@ LOGGER = getLogger(__name__)
 def scan_for_deprecated_env_vars(
     deprecated_env_vars: list, logger: Logger = LOGGER
 ) -> None:
-    """Scan for deprecated environment variables."""
+    """Scan for deprecated environment variables.
+
+    Args:
+        deprecated_env_vars (list): The deprecated environment variables.
+        logger (Logger, optional): The logger. Defaults to LOGGER.
+
+    Raises:
+        EnvironmentVariableDeprecatedError: Raised when an environment variable is deprecated.
+    """
 
     hemera_version = get_software_versions(distribution="hemera").package["hemera"]
 

--- a/src/hemera/exceptions.py
+++ b/src/hemera/exceptions.py
@@ -64,3 +64,10 @@ class GithubEventNotSupportedError(HemeraError):
 
     def __init__(self):
         raise HemeraError("GitHub event not supported.")
+
+
+class EnvironmentVariableDeprecatedError(HemeraError):
+    """Raised when an environment variable is deprecated."""
+
+    def __init__(self, env_var_name: str):
+        super().__init__(f"Environment variable {env_var_name} is deprecated.")

--- a/tests/hemera/conftest.py
+++ b/tests/hemera/conftest.py
@@ -37,14 +37,14 @@ def set_env_vars():
     os_environ["SLACK_API_TOKEN"] = "fake_token"
     os_environ["SLACK_CHANNEL"] = "fake_channel"
     os_environ["HOMEAUTOMATION_WEBHOOK"] = "http://fakeurl.com"
-    os_environ["ALLOWED_USERNAME"] = "username"
+    os_environ["PR_AUTHOR_FILTER"] = "username"
 
     yield
 
     os_environ.pop("SLACK_API_TOKEN", None)
     os_environ.pop("SLACK_CHANNEL", None)
     os_environ.pop("HOMEAUTOMATION_WEBHOOK", None)
-    os_environ.pop("ALLOWED_USERNAME", None)
+    os_environ.pop("PR_AUTHOR_FILTER", None)
 
 
 @pytest.fixture

--- a/tests/hemera/test_api_github.py
+++ b/tests/hemera/test_api_github.py
@@ -65,7 +65,7 @@ def test_github_api_message_sent_to_slack_successfully(
 
 def test_github_api_username_not_allowed(test_request: func.HttpRequest):
     """Test github_api when the username is not allowed."""
-    os_environ["ALLOWED_USERNAME"] = "fake_username"
+    os_environ["PR_AUTHOR_FILTER"] = "fake_username"
 
     test = github_api(req=test_request)
     assert test.get_body().decode() == "Error: Unauthorized user."

--- a/tests/hemera/test_deprecated.py
+++ b/tests/hemera/test_deprecated.py
@@ -1,0 +1,26 @@
+from os import environ as os_environ
+
+import pytest
+
+from hemera.dataclasses import DeprecatedEnvirionmentVariable
+from hemera.deprecated import scan_for_deprecated_env_vars
+from hemera.exceptions import HemeraError
+
+
+def test_scan_for_deprecated_env_vars():
+    os_environ["DEPRECATED_ENV_VAR"] = "test"
+
+    with pytest.raises(
+        HemeraError, match="Environment variable DEPRECATED_ENV_VAR is deprecated."
+    ):
+        scan_for_deprecated_env_vars(
+            deprecated_env_vars=[
+                DeprecatedEnvirionmentVariable(
+                    name="DEPRECATED_ENV_VAR",
+                    deprecated_in_hemera_version="0.0.0",
+                    replacement="NEW_ENV_VAR",
+                )
+            ]
+        )
+
+    os_environ.pop("DEPRECATED_ENV_VAR", None)


### PR DESCRIPTION
This commit adds a new feature to scan for deprecated environment variables in the code. It introduces a new module `hemera.deprecated` that contains the logic for scanning and logging warnings for deprecated environment variables. The `scan_for_deprecated_env_vars` function is called in the main function of `github/__init__.py` to check for deprecated environment variables and raise an error if necessary. This feature helps developers migrate from deprecated environment variables to their replacements.